### PR TITLE
fix: set transformCSS: 'pre' by default

### DIFF
--- a/packages/nuxt-windicss/src/module.ts
+++ b/packages/nuxt-windicss/src/module.ts
@@ -85,6 +85,7 @@ export default defineNuxtModule<ModuleOptions>({
         'nuxt-img': 'img',
       },
     },
+    transformCSS: 'pre',
   },
   async setup(options: ModuleOptions, nuxt) {
     const nuxtOptions = nuxt.options


### PR DESCRIPTION
see: https://windicss.org/integrations/vite.html#scoped-style

i haven't seen any negative impacts of pre transform after over a year of use, so this seems like a sensible default