### PR TITLE
fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ export default {
   css: [
     'virtual:windi.css',
     'virtual:windi-devtools',
-  },
+  ],
 }
 ```
 


### PR DESCRIPTION
Fixes a small typo in copy paste example of `css:[ ]` property