### PR TITLE
fix: @nuxtjs/tailwindcss not detected in Nuxt 2 / Bridge

### DIFF
--- a/packages/nuxt-windicss/src/module.ts
+++ b/packages/nuxt-windicss/src/module.ts
@@ -106,8 +106,8 @@ export default defineNuxtModule<ModuleOptions>({
 
     const installedModules = [
       ...nuxt.options.modules,
-      // Removed in Nuxt 3
-      // ...nuxt.options.buildModules,
+      // Not defined in Nuxt 3
+      ...(nuxt.options.buildModules || []),
     ]
     // Make sure they're not using tailwind
     // @todo move to a util


### PR DESCRIPTION
Because of the #192 fix, the `buildModules` is not checked to find the `@nuxtjs/tailwindcss`, so if a user of Nuxt 2 or Bridge have this module in his `buildModules`, the warning is not throw.